### PR TITLE
Added a timeout to __init__.py

### DIFF
--- a/googlesearch/__init__.py
+++ b/googlesearch/__init__.py
@@ -17,6 +17,7 @@ def _req(term, results, lang, start, proxies):
             start=start,
         ),
         proxies=proxies,
+        timeout=5 #prevents code from freezing. This is especially useful when using proxies since some proxies may not respond. 
     )
     resp.raise_for_status()
     return resp


### PR DESCRIPTION
Since requests seems to have a very long time out length, we can add a timeout in order to stop requests from blocking up our code. This is especially useful when using proxies that may not respond. In my opinion, 5 seconds seems like a quite generous time to allow a request to stay going for, but that can be changed to be longer. 