### PR TITLE
Loosen requirements. Fixes #22

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-beautifulsoup4==4.9.3
-requests==2.25.1
+beautifulsoup4>=4.9
+requests>=2.20


### PR DESCRIPTION
The strict requirements are causing problems for applications using this library as a dependency. If every dependency is strict, they can't be installed together. So best for libraries to be loose, and let the top level application be strict.

See https://github.com/Torantulino/Auto-GPT/issues/30