### PR TITLE
Packaging: Add requirements directly to setup.y

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-beautifulsoup4>=4.9
-requests>=2.20

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,14 @@ from setuptools import setup
 with open("README.md", "r", encoding='UTF-8') as fh:
     long_description = fh.read()
 
-with open("requirements.txt", "r", encoding='UTF-8') as fh:
-    requirements = fh.read().split("\n")
+requirements=[
+    "beautifulsoup4>=4.9",
+    "requests>=2.20",
+]
 
 setup(
     name="googlesearch-python",
-    version="1.2.0",
+    version="1.2.1",
     author="Nishant Vikramaditya",
     author_email="junk4Nv7@gmail.com",
     description="A Python library for scraping the Google search engine.",


### PR DESCRIPTION
Thx for creating release 1.2.0! Because requirements.txt was not packaged. unfortunately it failed with:
```
Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/tmp/pip-install-rnlvhfzw/googlesearch-python_6c9c2c2bfceb4afbafbe911906746a5f/setup.py", line 6, in <module>
          with open("requirements.txt") as fh:
      FileNotFoundError: [Errno 2] No such file or directory: 'requirements.txt'
```

The easiest way to fix this is to add requirements directly to setup.py - that's what this PR contains.


