### PR TITLE
Added SSL_VERIFY flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ from googlesearch import search
 
 proxy = 'http://API:@proxy.host.com:8080/'
 
-j = search("proxy test", num_results=100, lang="nl", proxy=proxy, SSL_VERIFY=False)
+j = search("proxy test", num_results=100, lang="en", proxy=proxy, SSL_VERIFY=False)
 for i in j:
     print(i)
 ```

--- a/README.md
+++ b/README.md
@@ -40,3 +40,13 @@ If requesting more than 100 results, googlesearch will send multiple requests to
 from googlesearch import search
 search("Google", sleep_interval=5, num_results=200)
 ```
+If you are using a HTTP Rotating Proxy which requires you to install their CA Certificate, you can simply add `SSL_VERIFY=False` in the `search()` method to avoid SSL Verification.
+```python
+from googlesearch import search
+
+proxy = 'http://API:@proxy.host.com:8080/'
+
+j = search("proxy test", num_results=100, lang="nl", proxy=proxy, SSL_VERIFY=False)
+for i in j:
+    print(i)
+```

--- a/googlesearch/__init__.py
+++ b/googlesearch/__init__.py
@@ -6,7 +6,7 @@ from .user_agents import get_useragent
 import urllib
 
 
-def _req(term, results, lang, start, proxies, timeout):
+def _req(term, results, lang, start, proxies, timeout, SSL_VERIFY):
     resp = get(
         url="https://www.google.com/search",
         headers={
@@ -20,6 +20,7 @@ def _req(term, results, lang, start, proxies, timeout):
         },
         proxies=proxies,
         timeout=timeout,
+        verify=SSL_VERIFY,
     )
     resp.raise_for_status()
     return resp
@@ -35,7 +36,7 @@ class SearchResult:
         return f"SearchResult(url={self.url}, title={self.title}, description={self.description})"
 
 
-def search(term, num_results=10, lang="en", proxy=None, advanced=False, sleep_interval=0, timeout=5):
+def search(term, num_results=10, lang="en", proxy=None, advanced=False, sleep_interval=0, timeout=5, SSL_VERIFY=None):
     """Search the Google search engine"""
 
     escaped_term = urllib.parse.quote_plus(term) # make 'site:xxx.xxx.xxx ' works.
@@ -53,7 +54,7 @@ def search(term, num_results=10, lang="en", proxy=None, advanced=False, sleep_in
     while start < num_results:
         # Send request
         resp = _req(escaped_term, num_results - start,
-                    lang, start, proxies, timeout)
+                    lang, start, proxies, timeout, SSL_VERIFY)
 
         # Parse
         soup = BeautifulSoup(resp.text, "html.parser")


### PR DESCRIPTION
Added SSL_VERIFY flag as with some of the proxy providers it throws SSL errors like below:

(Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1129)')))

This flag will take "True" or "False" or path-to-ca.crt file.

It also helps in not installing and configuring the Proxy CA cert for each proxy provider every time in case of planning to use a proxy provider temporarily.