### PR TITLE
Fix Incorrect Proxy Setting Usage in Request Module

### DIFF
--- a/googlesearch/__init__.py
+++ b/googlesearch/__init__.py
@@ -40,7 +40,7 @@ def search(term, num_results=10, lang="en", proxy=None, advanced=False, sleep_in
     escaped_term = term.replace(" ", "+")
 
     # Proxy setup
-    proxies = {"https": proxy} if proxy and proxy.startswith("https") else {"http": proxy} if proxy else None
+    proxies = {"https": proxy, "http": proxy} if proxy and (proxy.startswith("https") or proxy.startswith("http")) else None
 
     start = 0
     fetched_results = 0  # Keep track of the total fetched results

--- a/googlesearch/__init__.py
+++ b/googlesearch/__init__.py
@@ -45,10 +45,11 @@ def search(term, num_results=10, lang="en", proxy=None, advanced=False, sleep_in
     # Proxy
     proxies = None
     if proxy:
-        if proxy.startswith("https"):
-            proxies = {"https": proxy}
-        else:
-            proxies = {"http": proxy}
+        if proxy.startswith("http://") or proxy.startswith("https://"):
+            proxies = {
+                "https": proxy,
+                "http": proxy
+            }
 
     # Fetch
     start = 0


### PR DESCRIPTION
## Description

The current implementation of the proxy setting in the `search` function does not handle proxies correctly. Specifically, if a proxy is set with the format `http://proxy_host:port`, it does not handle `https` requests to proxy, which is required for Google search.

## Related Issues

#73 

## Solution

This PR updates the proxy setting logic to correctly configure the proxy for both `http` and `https` protocols when the proxy URL starts with `http://` or `https://`. This ensures that `https` requests are properly routed through the proxy even when the proxy URL is specified with `http://`.

## Changes Made

Updated the proxy setting logic to configure proxies for both `http` and `https` protocols properly.

### Old Code

```
if proxy:
    if proxy.startswith("https"):
        proxies = {"https": proxy}
    else:
        proxies = {"http": proxy}
```

### New Code

```
if proxy.startswith("http://") or proxy.startswith("https://"):
    proxies = {
        "https": proxy,
        "http": proxy
    }
```
