### PR TITLE
Added Option to Get Unique Search Results

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ googlesearch supports a few additional options. By default, googlesearch returns
 from googlesearch import search
 search("Google", num_results=100)
 ```
+If you want to have unique links in your search result, you can use the `unique` option as in the following program.
+```python
+from googlesearch import search
+search("Google", num_results=100, unique=True)
+```
 In addition, you can change the language google searches in. For example, to get results in French run the following program:
 ```python
 from googlesearch import search

--- a/googlesearch/__init__.py
+++ b/googlesearch/__init__.py
@@ -37,7 +37,7 @@ class SearchResult:
         return f"SearchResult(url={self.url}, title={self.title}, description={self.description})"
 
 
-def search(term, num_results=10, lang="en", proxy=None, advanced=False, sleep_interval=0, timeout=5, safe="active", ssl_verify=None, region=None, start_num=0):
+def search(term, num_results=10, lang="en", proxy=None, advanced=False, sleep_interval=0, timeout=5, safe="active", ssl_verify=None, region=None, start_num=0, unique=False):
     """Search the Google search engine"""
 
     # Proxy setup
@@ -45,6 +45,7 @@ def search(term, num_results=10, lang="en", proxy=None, advanced=False, sleep_in
 
     start = start_num
     fetched_results = 0  # Keep track of the total fetched results
+    fetched_links = set() # to keep track of links that are already seen previously
 
     while fetched_results < num_results:
         # Send request
@@ -63,6 +64,10 @@ def search(term, num_results=10, lang="en", proxy=None, advanced=False, sleep_in
             description_box = result.find("div", {"style": "-webkit-line-clamp:2"})
 
             if link and title and description_box:
+                link = result.find("a", href=True)
+                if link["href"] in fetched_links and unique:
+                    continue
+                fetched_links.add(link["href"])
                 description = description_box.text
                 fetched_results += 1
                 new_results += 1


### PR DESCRIPTION
Fixes #88 
With this we can get unique results just by setting the `unique` option to `True` which is `False` by default.

Example Usage:
```python
from googlesearch import search
search("Ai for education", num_results=10, unique=True)
```