### PR TITLE
Fixed pages that started with a wiki item and igore comitting the vsc…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,10 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Visual Studio Code
+#  The Visual Studio Code ignore file is maintained in a separate Visual-Studio-Code.gitignore that
+#  can be found at https://github.com/github/gitignore/blob/main/Global/Visual-Studio-Code.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire vscode folder.
+.vscode/

--- a/googlesearch/__init__.py
+++ b/googlesearch/__init__.py
@@ -62,6 +62,9 @@ def search(term, num_results=10, lang="en", proxy=None, advanced=False, sleep_in
             link = result.find("a", href=True)
             title = result.find("h3")
             description_box = result.find("div", {"style": "-webkit-line-clamp:2"})
+            if not description_box:
+                # Page started with Wiki items should find the description here
+                description_box = result.find("div", {"style": "grid-area:nke7rc"})
 
             if link and title and description_box:
                 link = result.find("a", href=True)


### PR DESCRIPTION
Some serach result pages with a wiki item in the top don't diaply the description in the div with style "-webkit-line-clamp:2" but "grid-area:nke7rc". I fixed it to get the correct description. 