### PR TITLE
Update README.md for socks5h

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ from googlesearch import search
 proxy = 'http://username:password@proxy.host.com:8080/'
 # or for socks5
 # proxy = 'socks5://username:password@proxy.host.com:1080/'
+# Use socks5h:// if you want DNS resolution to happen through the SOCKS5 proxy, ensuring better privacy and avoiding DNS leakage.
+# proxy = 'socks5h://username:password@proxy.host.com:1080/'   
 
 j = search("proxy test", num_results=100, lang="en", proxy=proxy, ssl_verify=False)
 for i in j:


### PR DESCRIPTION
- Use socks5h:// if you want DNS resolution to happen through the SOCKS5 proxy, ensuring better privacy and avoiding DNS leakage.
- Use socks5:// if you're okay with DNS resolution happening locally on the client.

This distinction is important when using tools like curl, networking libraries, or applications that rely on proxies.


---

I found that requests often fail because of this detail, and I just encountered it again. Let's add it to the documentation.

---

Additionally, I think this SOCKS proxy feature is very useful, but the current version on PyPI doesn't include this feature. If possible, could you release a new version to PyPI?😄